### PR TITLE
Allow minor version updates to selenium-webdriver

### DIFF
--- a/test-runner/package.json
+++ b/test-runner/package.json
@@ -24,7 +24,7 @@
   "author": "Paul Lewis",
   "license": "Apache-2.0",
   "dependencies": {
-    "selenium-webdriver": "^2.48.0",
+    "selenium-webdriver": "~2.48.0",
     "yargs": "^3.29.0"
   },
   "repository": {


### PR DESCRIPTION
This fixes an error where 'webdriver.WebDriver.Logs' doesn't exist when running `runner.js`.

_CLA submitted_